### PR TITLE
Add proxy-related headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = function nocache(options) {
 
   return async function nocacheMiddleware(ctx, next) {
     if (methods.includes(ctx.method)) {
-      ctx.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      ctx.set('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate');
+      ctx.set('Surrogate-Control', 'no-store');
       ctx.set('Expires', '0');
       ctx.set('Pragma', 'no-cache');
     }

--- a/test/nocache_test.js
+++ b/test/nocache_test.js
@@ -17,8 +17,9 @@ describe('Test nocache middleware', function() {
     request(app.callback()).get('/')
       .expect(200)
       .expect('Expires', '0')
-      .expect('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate')
       .expect('Pragma', 'no-cache')
+      .expect('Surrogate-Control', 'no-store')
       .end(done);
   });
 
@@ -34,8 +35,9 @@ describe('Test nocache middleware', function() {
     request(app.callback()).put('/')
       .expect(200)
       .expect('Expires', '0')
-      .expect('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate')
       .expect('Pragma', 'no-cache')
+      .expect('Surrogate-Control', 'no-store')
       .end(done);
   });
 
@@ -60,6 +62,7 @@ describe('Test nocache middleware', function() {
         expect(res.headers).to.not.include.key('expires');
         expect(res.headers).to.not.include.key('cache-control');
         expect(res.headers).to.not.include.key('pragma');
+        expect(res.headers).to.not.include.key('Surrogate-Control');
 
         done();
       });
@@ -82,8 +85,9 @@ describe('Test nocache middleware', function() {
     request(app.callback()).get('/api/bar')
       .expect(200)
       .expect('Expires', '0')
-      .expect('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate')
       .expect('Pragma', 'no-cache')
+      .expect('Surrogate-Control', 'no-store')
       .end(done);
   });
 
@@ -102,8 +106,9 @@ describe('Test nocache middleware', function() {
     request(app.callback()).get('/api/bar')
       .expect(200)
       .expect('Expires', '0')
-      .expect('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate')
       .expect('Pragma', 'no-cache')
+      .expect('Surrogate-Control', 'no-store')
       .end(done);
   });
 
@@ -131,6 +136,7 @@ describe('Test nocache middleware', function() {
         expect(res.headers).to.not.include.key('expires');
         expect(res.headers).to.not.include.key('cache-control');
         expect(res.headers).to.not.include.key('pragma');
+        expect(res.headers).to.not.include.key('surrogate-control');
 
         done();
       });
@@ -151,8 +157,9 @@ describe('Test nocache middleware', function() {
     request(app.callback()).post('/api/foobar')
       .expect(200)
       .expect('Expires', '0')
-      .expect('Cache-Control', 'no-cache, no-store, must-revalidate')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate, proxy-revalidate')
       .expect('Pragma', 'no-cache')
+      .expect('Surrogate-Control', 'no-store')
       .end(done);
   });
 });


### PR DESCRIPTION
 1. Add `Surrogate-Control` header with value `no-store` value to prohibit caching at the surrogates (aka "reverse proxies") - [RFC](https://www.w3.org/TR/edge-arch/)

2. Add `proxy-revalidate` value to the `Cache-Control` header - public-cache specific version of `must-revalidate`

This would make headers the same as set by https://github.com/helmetjs/nocache. 